### PR TITLE
Fix possible error E5560 when notifying

### DIFF
--- a/lua/chezmoi/notify.lua
+++ b/lua/chezmoi/notify.lua
@@ -5,7 +5,12 @@ local plugin = "chezmoi.nvim"
 local function plain(text, level, opts)
   opts = opts or {}
   opts.title = plugin
-  vim.notify(text, level, opts)
+
+  if vim.in_fast_event() then
+    vim.schedule(function() vim.notify(text, level, opts) end)
+  else
+    vim.notify(text, level, opts)
+  end
 end
 
 function notify.info(text, opts)


### PR DESCRIPTION
Hi ! Hope it is fine to open a PR like this.

I started using chezmoi.nvim with the following config and [rcarriga/nvim-notify](https://github.com/rcarriga/nvim-notify) as a `vim.notify` backend.
```
{
  edit = {
    watch = true,
  },
}
```

But I recently changed my `vim.notify` backend to [j-hui/fidget.nvim](https://github.com/j-hui/fidget.nvim) and started to experience the following errors when saving a chezmoi managed buffer.
```
"~/.local/share/chezmoi/dot_config/nvim/lua/jbmorice/plugins/lspconfig.lua" 106L, 3437B written
Error detected while processing BufWritePost Autocommands for "<buffer=13>":
Error executing lua callback: ...ta/Local/nvim-data/lazy/plenary.nvim/lua/plenary/job.lua:499: 'chezmoi apply --source-path C:
/Users/Jean-Baptiste/.local/share/chezmoi/dot_config/nvim/lua/jbmorice/plugins/lspconfig.lua' was unable to complete in 5000 m
s
stack traceback:
        [C]: in function 'error'
        ...ta/Local/nvim-data/lazy/plenary.nvim/lua/plenary/job.lua:499: in function 'wait'
        ...ta/Local/nvim-data/lazy/plenary.nvim/lua/plenary/job.lua:453: in function 'sync'
        ...m-data/lazy/chezmoi.nvim/lua/chezmoi/commands/__base.lua:38: in function 'execute'
        ...m-data/lazy/chezmoi.nvim/lua/chezmoi/commands/__edit.lua:56: in function <...m-data/lazy/chezmoi.nvim/lua/chezmoi/c
ommands/__edit.lua:46>

Error executing luv callback:
...-data/lazy/fidget.nvim/lua/fidget/notification/model.lua:264: E5560: vimL function must not be called in a lua loop callbac
k
stack traceback:
        [C]: in function 'sort'
        ...-data/lazy/fidget.nvim/lua/fidget/notification/model.lua:264: in function 'update'
        ...l/nvim-data/lazy/fidget.nvim/lua/fidget/notification.lua:257: in function 'notify'
        ...Local/nvim-data/lazy/chezmoi.nvim/lua/chezmoi/notify.lua:8: in function 'plain'
        ...Local/nvim-data/lazy/chezmoi.nvim/lua/chezmoi/notify.lua:12: in function 'info'
        ...m-data/lazy/chezmoi.nvim/lua/chezmoi/commands/__edit.lua:62: in function '_user_on_exit'
        ...ta/Local/nvim-data/lazy/plenary.nvim/lua/plenary/job.lua:240: in function '_shutdown'
        ...ta/Local/nvim-data/lazy/plenary.nvim/lua/plenary/job.lua:47: in function <...ta/Local/nvim-data/lazy/plenary.nvim/l
ua/plenary/job.lua:38>
        [C]: in function 'wait'
        ...ta/Local/nvim-data/lazy/plenary.nvim/lua/plenary/job.lua:486: in function 'wait'
        ...ta/Local/nvim-data/lazy/plenary.nvim/lua/plenary/job.lua:453: in function 'sync'
        ...m-data/lazy/chezmoi.nvim/lua/chezmoi/commands/__base.lua:38: in function 'execute'
        ...m-data/lazy/chezmoi.nvim/lua/chezmoi/commands/__edit.lua:56: in function <...m-data/lazy/chezmoi.nvim/lua/chezmoi/c
ommands/__edit.lua:46>
```

I am not very experienced with lua and neovim development but here is my understanding of the issue:
- sometimes the callbacks of the plenary jobs used to run chezmoi commands are executed in a "fast" event handler;
- "fast" event handlers restricts vim API usage drastically, and an error E5560 occurs when an unauthorized call is made;
- and a `vim.notify` backend may use unauthorized vim functions in its implementation (like [j-hui/fidget.nvim](https://github.com/j-hui/fidget.nvim) seems to do in [here](https://github.com/j-hui/fidget.nvim/blob/main/lua/fidget/notification/model.lua#L264)). 

The solution I found was to guard the `vim.notify` call in `lua/chezmoi/notify.lua` by a `vim.in_fast_event()` check and passing it through a `vim.schedule` call when it is true.

And thanks four your work on this plugin, it has greatly improved my workflow when editing my neovim config. 😃 