### PR TITLE
Update README.md with Fzf-lua integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ telescope.load_extension('chezmoi')
 vim.keymap.set('n', '<leader>cz', telescope.extensions.chezmoi.find_files, {})
 ```
 
+### fzf-lua Integration
+```lua
+fzf_chezmoi = function()
+  require'fzf-lua'.fzf_exec(require("chezmoi.commands").list(), {
+    actions = {
+      ['default'] = function(selected, opts)
+	require("chezmoi.commands").edit({
+	  targets = {"~/" .. selected[1]},
+	  args = { "--watch" }
+	})
+      end
+    }
+  })
+end
+
+vim.api.nvim_command('command! ChezmoiFzf lua fzf_chezmoi()')
+```
+
 ## User Command
 ```vim
 :ChezmoiEdit <target> <args>


### PR DESCRIPTION
I'm using [fzf-lua](https://github.com/ibhagwan/fzf-lua) instead of telescope. This code allows you to navigate and open the files using fzf-lua

<img width="478" alt="image" src="https://github.com/xvzc/chezmoi.nvim/assets/7526373/0c826190-a7e3-4f97-8c3d-e4a39458a8cb">
