### PR TITLE
fix: exclude externals file type in telescope extension

### DIFF
--- a/lua/telescope/_extensions/find_files.lua
+++ b/lua/telescope/_extensions/find_files.lua
@@ -19,6 +19,8 @@ function find.execute(opts)
       "absolute",
       "--include",
       "files",
+      "--exclude",
+      "externals",
     },
   }
 


### PR DESCRIPTION
Closes #17