### PR TITLE
docs: safer autocmd for auto-applying edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ The below configuration wll allow you to automatically apply changes on files un
 ```lua
 --  e.g. ~/.local/share/chezmoi/*
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
-	pattern = { os.getenv("HOME") .. "/.local/share/chezmoi/*" },
-	callback = function()
-    vim.schedule(require("chezmoi.commands.__edit").watch)
-	end,
+    pattern = { os.getenv("HOME") .. "/.local/share/chezmoi/*" },
+    callback = function(ev)
+        local bufnr = ev.buf
+        local edit_watch = function()
+            require("chezmoi.commands.__edit").watch(bufnr)
+        end
+        vim.schedule(edit_watch)
+    end,
 })
 ```
 


### PR DESCRIPTION
I encountered a small problem with the example auto-apply callback function when using `nvim -d` as the `chezmoi merge` tool. The autocmd was working fine in most cases, but in this case I kept getting a `chezmoi status` error message about a file that wasn't in the Chezmoi source directory even though the filename didn't match the autocmd pattern.

It took me a little while to figure out what was going on, so I thought I would submit my fix in case anyone else might have the same problem. It turns out that when multiple windows are opened from the `nvim` command line, the buffer that is current when `vim.schedule` makes the deferred call to the `watch` function may not be the same buffer on which the autocmd fired. Since the `watch` function will use the current buffer from `nvim_get_current_buf()` if no buffer number argument is passed, this sometimes causes it to try to process the wrong buffer.

The optional event argument passed to the `callback` function contains the correct buffer number, and the buffer number can be passed to the `watch` function, but `vim.schedule` requires a function with no arguments. The solution is to create a local closure function that captures the buffer number and passes it in the `watch` call. The closure function can then be used with `vim.schedule`, and the `watch` function will receive the correct buffer number regardless of which buffer is current at the time of the actual call.