### PR TITLE
Use bufname builtin to avoid symlink resolution

### DIFF
--- a/lua/chezmoi/commands/__edit.lua
+++ b/lua/chezmoi/commands/__edit.lua
@@ -39,7 +39,7 @@ function M.watch(bufnr, force)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   force = force or config.edit.force
 
-  local source_path = vim.api.nvim_buf_get_name(bufnr)
+  local source_path = vim.fn.bufname(bufnr)
   local event = { "BufWritePost" }
 
   local status_err = nil


### PR DESCRIPTION
On Fedora Silerblue which is built around OSTree, the `/home` directory is a symlink to `/var/home`.

This causes an error when `status --source-path` is called with the resolved filepath. For example:

```console
$ chezmoi status --source-path ~/.local/share/chezmoi/dot_bashrc
[no error]
$ chezmoi status --source-path (realpath ~/.local/share/chezmoi/dot_bashrc)
chezmoi: /var/home/sqwxl/.local/share/chezmoi/dot_bashrc: not in /home/sqwxl/.local/share/chezmoi
```

In the plugin, `vim.api.nvim_buf_get_name` returns the real (resolved) path of the buffer. Hence,

```console
:lua require("chezmoi.commands.__status").execute({ args = { "--source-path", vim.api.nvim_buf_get_name(0) }})
```

results in the same error. 

The vim builtin function `bufname()` can be used instead of the API function, as it doesn't resolve the symlink.

Edit: Since this isn't really a bug with this plugin I also opened an upstream issue: https://github.com/twpayne/chezmoi/issues/4006