### PR TITLE
fix: guard against text being nil

### DIFF
--- a/lua/chezmoi/notify.lua
+++ b/lua/chezmoi/notify.lua
@@ -3,6 +3,10 @@ local notify = {}
 local plugin = "chezmoi.nvim"
 
 local function plain(text, level, opts)
+  if text == nil then
+    return
+  end
+
   opts = opts or {}
   opts.title = plugin
 


### PR DESCRIPTION
This PR adds a nil check to prevent raising an error if a `notify` call is triggered while the notification category is disabled.

My config is as follows:
```lua
require("chezmoi").setup({
	edit = {
		watch = true,
		force = true,
	},
	notification = {
		on_open = true,
		on_apply = false, -- currently raises error
		on_watch = true,
	},
})
```