### PR TITLE
feat: Add targets option to telescope finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ vim.keymap.set('n', '<leader>cz', telescope.extensions.chezmoi.find_files, {})
 -- You can also search a specific target directory and override arguments
 -- Here is an example with the default args
 vim.keymap.set('n', '<leader>fc', function()
-  telescope.extensions.chezmoi.find_files(
-    {},
-    vim.fn.stdpath("config"),
-    {
+  extensions.chezmoi.find_files({
+    targets = vim.fn.stdpath("config"),
+    args = {
       "--path-style",
       "absolute",
       "--include",
@@ -92,7 +91,7 @@ vim.keymap.set('n', '<leader>fc', function()
       "--exclude",
       "externals",
     }
-  )
+  })
 end, {})
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ vim.keymap.set('n', '<leader>cz', telescope.extensions.chezmoi.find_files, {})
 -- You can also search a specific target directory and override arguments
 -- Here is an example with the default args
 vim.keymap.set('n', '<leader>fc', function()
-  extensions.chezmoi.find_files({
-    targets = vim.fn.stdpath("config"),
-    args = {
+  telescope.extensions.chezmoi.find_files(
+    {},
+    vim.fn.stdpath("config"),
+    {
       "--path-style",
       "absolute",
       "--include",
@@ -91,7 +92,7 @@ vim.keymap.set('n', '<leader>fc', function()
       "--exclude",
       "externals",
     }
-  })
+  )
 end, {})
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,20 @@ telescope.setup {
 
 telescope.load_extension('chezmoi')
 vim.keymap.set('n', '<leader>cz', telescope.extensions.chezmoi.find_files, {})
--- You can also search a specific directory, for example
+-- You can also search a specific target directory and override arguments
+-- Here is an example with the default args
 vim.keymap.set('n', '<leader>fc', function()
-  extensions.chezmoi.find_files({targets = vim.fn.stdpath("config")})
+  extensions.chezmoi.find_files({
+    targets = vim.fn.stdpath("config"),
+    args = {
+      "--path-style",
+      "absolute",
+      "--include",
+      "files",
+      "--exclude",
+      "externals",
+    }
+  })
 end, {})
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ telescope.setup {
 
 telescope.load_extension('chezmoi')
 vim.keymap.set('n', '<leader>cz', telescope.extensions.chezmoi.find_files, {})
+-- You can also search a specific directory, for example
+vim.keymap.set('n', '<leader>fc', function()
+  extensions.chezmoi.find_files({targets = vim.fn.stdpath("config")})
+end, {})
 ```
 
 ### fzf-lua Integration

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ vim.keymap.set('n', '<leader>cz', telescope.extensions.chezmoi.find_files, {})
 -- You can also search a specific target directory and override arguments
 -- Here is an example with the default args
 vim.keymap.set('n', '<leader>fc', function()
-  extensions.chezmoi.find_files({
+  telescope.extensions.chezmoi.find_files({
     targets = vim.fn.stdpath("config"),
     args = {
       "--path-style",

--- a/lua/telescope/_extensions/find_files.lua
+++ b/lua/telescope/_extensions/find_files.lua
@@ -10,7 +10,7 @@ local finders = require "telescope.finders"
 
 local find = {}
 
-function find.execute(opts)
+function find.execute(opts, dirs, args)
   opts = opts or {}
   local default_args = {
     "--path-style",
@@ -20,11 +20,10 @@ function find.execute(opts)
     "--exclude",
     "externals",
   }
-  local args = opts.args or default_args
 
   local list = chezmoi_commands.list {
-    targets = opts.targets,
-    args = args,
+    targets = dirs,
+    args = args or default_args,
   }
 
   opts.cwd = os.getenv("HOME")

--- a/lua/telescope/_extensions/find_files.lua
+++ b/lua/telescope/_extensions/find_files.lua
@@ -12,17 +12,19 @@ local find = {}
 
 function find.execute(opts)
   opts = opts or {}
+  local default_args = {
+    "--path-style",
+    "absolute",
+    "--include",
+    "files",
+    "--exclude",
+    "externals",
+  }
+  local args = opts.args or default_args
 
   local list = chezmoi_commands.list {
     targets = opts.targets,
-    args = {
-      "--path-style",
-      "absolute",
-      "--include",
-      "files",
-      "--exclude",
-      "externals",
-    },
+    args = args,
   }
 
   opts.cwd = os.getenv("HOME")

--- a/lua/telescope/_extensions/find_files.lua
+++ b/lua/telescope/_extensions/find_files.lua
@@ -10,7 +10,7 @@ local finders = require "telescope.finders"
 
 local find = {}
 
-function find.execute(opts, dirs, args)
+function find.execute(opts)
   opts = opts or {}
   local default_args = {
     "--path-style",
@@ -20,10 +20,11 @@ function find.execute(opts, dirs, args)
     "--exclude",
     "externals",
   }
+  local args = opts.args or default_args
 
   local list = chezmoi_commands.list {
-    targets = dirs,
-    args = args or default_args,
+    targets = opts.targets,
+    args = args,
   }
 
   opts.cwd = os.getenv("HOME")

--- a/lua/telescope/_extensions/find_files.lua
+++ b/lua/telescope/_extensions/find_files.lua
@@ -14,6 +14,7 @@ function find.execute(opts)
   opts = opts or {}
 
   local list = chezmoi_commands.list {
+    targets = opts.targets,
     args = {
       "--path-style",
       "absolute",


### PR DESCRIPTION
Hi!

This simply adds the `targets` option to the telescope picker so that one can pick files in a specific directory.

To make this consistent with other telescope pickers, one alternative would be to accept `cwd` instead and set `target` to that.

Let me know what would be best or if you have other comments.

Thank you!