### PR TITLE
feat: Support file and CLI args completion for `ChezmoiEdit`

### DIFF
--- a/lua/chezmoi/util.lua
+++ b/lua/chezmoi/util.lua
@@ -35,7 +35,7 @@ function M.__classify_args(tbl)
 
   local args_start_idx = nil
   for i, v in ipairs(tbl) do
-    if v ~= "" and v[1] == '-' then
+    if v ~= "" and string.sub(v, 1, 1) == '-' then
       args_start_idx = i
       break
     end

--- a/plugin/chezmoi.lua
+++ b/plugin/chezmoi.lua
@@ -16,14 +16,14 @@ local command_entry = {
     local targets, args = parse_args(args_all)
     commands.edit({
       targets = targets,
-      args = args
+      args = args,
     })
   end,
   list = function(args_all)
     local targets, args = parse_args(args_all)
     local managed_files = commands.list({
       targets = targets,
-      args = args
+      args = args,
     })
 
     local out = ""
@@ -40,10 +40,26 @@ local function load_command(cmd, ...)
   command_entry[cmd](args)
 end
 
+local function edit_complete(arg_lead, cmd_line, cursor_pos)
+  -- This automatically filters arguments
+  local completions = vim.fn.getcompletion(arg_lead, "file")
+
+  -- customlist behaviour does not filter args, so we do it here
+  local accepted_args = { "--watch", "--force" }
+  for _, arg in ipairs(accepted_args) do
+    if arg:find(arg_lead, 1, true) then
+      table.insert(completions, arg)
+    end
+  end
+
+  return completions
+end
+
 vim.api.nvim_create_user_command("ChezmoiEdit", function(opts)
   load_command("edit", unpack(opts.fargs))
 end, {
   nargs = "*",
+  complete = edit_complete, -- lua function equivalent to customlist
 })
 
 vim.api.nvim_create_user_command("ChezmoiList", function(opts)


### PR DESCRIPTION
This adds completion support to ChezmoiEdit for files and the `--watch` and `--force` arguments (which are documented in the readme).

I did not add completion to `ChezmoiList` because I was not sure how to handle completing all supported CLI arguments. Happy to add path completion if it is useful there as well.

Thanks!