### PR TITLE
Fix substring match in identification of CLI args

### DIFF
--- a/lua/chezmoi/util.lua
+++ b/lua/chezmoi/util.lua
@@ -35,7 +35,7 @@ function M.__classify_args(tbl)
 
   local args_start_idx = nil
   for i, v in ipairs(tbl) do
-    if v ~= "" and v[1] == '-' then
+    if v ~= "" and string.sub(v, 1, 1) == '-' then
       args_start_idx = i
       break
     end


### PR DESCRIPTION
I tried adding the `--watch` arg to `ChezmoiEdit` and it failed to recognize it.

The issue as that `v[1]` does not return the first character, but `nil`. This replaces it with a substring match and fixes the issue.

Thanks!