### PR TITLE
Replace deprecated `vim.tbl_flatten()` with `vim.iter():flatten():totable()`

### DIFF
--- a/lua/chezmoi/commands/__apply.lua
+++ b/lua/chezmoi/commands/__apply.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@param opts Options
 function M.execute(opts)
   opts = opts or {}
-  opts.targets = vim.tbl_flatten { opts.targets or {} }
+  opts.targets = vim.iter({ opts.targets or {} }):flatten():totable()
   opts.args = util.__normalize_args(opts.args)
 
   return base.execute(vim.tbl_deep_extend("keep", { cmd = "apply" }, opts))

--- a/lua/chezmoi/commands/__base.lua
+++ b/lua/chezmoi/commands/__base.lua
@@ -36,7 +36,7 @@ function M.execute(opts)
 
   local job = Job:new {
     command = "chezmoi",
-    args = vim.tbl_flatten { opts.cmd, opts.targets, opts.args },
+    args = vim.iter({ opts.cmd, opts.targets, opts.args }):flatten():totable(),
     on_stderr = opts.on_stderr or on_stderr_default,
     on_exit = opts.on_exit,
   }

--- a/lua/chezmoi/commands/__edit.lua
+++ b/lua/chezmoi/commands/__edit.lua
@@ -110,7 +110,7 @@ end
 ---@param opts { targets?: any, args: string[]? }
 function M.execute(opts)
   opts = opts or {}
-  opts.targets = vim.tbl_flatten { opts.targets or {} }
+  opts.targets = vim.iter({ opts.targets or {} }):flatten():totable()
   local custom_opts = M.__parse_custom_opts(opts.args or {})
 
   if vim.tbl_isempty(opts.targets) then

--- a/lua/chezmoi/commands/__list.lua
+++ b/lua/chezmoi/commands/__list.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@param opts Options
 function M.execute(opts)
   opts = opts or {}
-  opts.targets = vim.tbl_flatten { opts.targets or {} }
+  opts.targets = vim.iter({ opts.targets or {} }):flatten():totable()
   opts.args = util.__normalize_args(opts.args)
 
   return base.execute(vim.tbl_deep_extend("keep", { cmd = "list" }, opts))

--- a/lua/chezmoi/commands/__source-path.lua
+++ b/lua/chezmoi/commands/__source-path.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@param opts Options
 function M.execute(opts)
   opts = opts or {}
-  opts.targets = vim.tbl_flatten { opts.targets or {} }
+  opts.targets = vim.iter({ opts.targets or {} }):flatten():totable()
   opts.args = util.__normalize_args(opts.args)
 
   return base.execute(vim.tbl_deep_extend("keep", { cmd = "source-path" }, opts))

--- a/lua/chezmoi/commands/__status.lua
+++ b/lua/chezmoi/commands/__status.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@param opts Options
 function M.execute(opts)
   opts = opts or {}
-  opts.targets = vim.tbl_flatten { opts.targets or {} }
+  opts.targets = vim.iter({ opts.targets or {} }):flatten():totable()
   opts.args = util.__normalize_args(opts.args)
 
   return base.execute(vim.tbl_deep_extend("keep", { cmd = "status" }, opts))

--- a/lua/chezmoi/commands/__target-path.lua
+++ b/lua/chezmoi/commands/__target-path.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@param opts Options
 function M.execute(opts)
   opts = opts or {}
-  opts.targets = vim.tbl_flatten { opts.targets or {} }
+  opts.targets = vim.iter({ opts.targets or {} }):flatten():totable()
   opts.args = util.__normalize_args(opts.args)
 
   return base.execute(vim.tbl_deep_extend("keep", { cmd = "target-path" }, opts))


### PR DESCRIPTION
`vim.tbl_flatten()` will be deprecated in 0.13. This replaces it.