### PR TITLE
feat: edit encrypted files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@
   edit = {
     watch = false,
     force = false,
+    -- Edit Age encrypted files
+    encrypted = false,
   },
   events = {
     on_open = {
@@ -69,7 +71,7 @@
 ```
 
 ### Automatically Running `chezmoi apply` In Specific Directories
-The below configuration wll allow you to automatically apply changes on files under chezmoi source path.
+The below configuration will allow you to automatically apply changes on files under chezmoi source path.
 ```lua
 --  e.g. ~/.local/share/chezmoi/*
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
@@ -158,7 +160,7 @@ print(vim.inspect(managed_files))
 
 ### Edit
 ```lua
--- NOTE: chezmoi.nvim utilizes builtin neovim functions for file editing instead of `chzmoi edit`
+-- NOTE: chezmoi.nvim utilizes builtin neovim functions for file editing instead of `chezmoi edit`
 require("chezmoi.commands").edit({
     targets = { "~/.zshrc" },
     args = { "--watch" }

--- a/lua/chezmoi/commands/__base.lua
+++ b/lua/chezmoi/commands/__base.lua
@@ -12,12 +12,14 @@ local M = {}
 ---@field args? string[]
 ---@field on_exit? fun(code: number, signal: number)
 ---@field on_stderr? fun(error: string, data: string)
+---@field writer? Job|table|string
 
 ---@param opts Options
 function M.execute(opts)
   opts = opts or {}
   opts.targets = opts.targets or {}
   opts.args = opts.args or {}
+  opts.writer = opts.writer or {}
   for _, v in ipairs(config.extra_args) do
     table.insert(opts.args, v)
   end
@@ -43,6 +45,7 @@ function M.execute(opts)
     args = vim.iter({ opts.cmd, opts.targets, opts.args }):flatten():totable(),
     on_stderr = opts.on_stderr or on_stderr_default,
     on_exit = opts.on_exit,
+    writer = opts.writer,
   }
 
   job:sync()

--- a/lua/chezmoi/init.lua
+++ b/lua/chezmoi/init.lua
@@ -5,6 +5,7 @@ local default_config = {
   edit = {
     watch = false,
     force = false,
+    encrypted = false,
   },
   events = {
     on_open = {


### PR DESCRIPTION
Disabled by default, option 'config.edit.encrypted' to enabled.
Use Chezmoi encryption feature when configure with no passphrase: https://www.chezmoi.io/user-guide/encryption/age/.
Load in an buffer decrypted content using 'chezmoi decrypt'.
Encrypt and write using 'chezmoi encrypt -o'.

