### PR TITLE
feat: add `ignore_patterns` to prevent auto-apply on chezmoi meta-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@
   edit = {
     watch = false,
     force = false,
+    ignore_patterns = {
+      "run_onchange_.*",
+      "run_once_.*", 
+      "%.chezmoiignore",
+      "%.chezmoitemplate",
+      -- Add custom patterns here
+    },
   },
   events = {
     on_open = {
@@ -67,6 +74,8 @@
   },
 }
 ```
+
+The `ignore_patterns` option accepts Lua patterns to match against filenames. Files matching these patterns will not trigger automatic `chezmoi apply` when saved, even if watch mode is enabled.
 
 ### Automatically Running `chezmoi apply` In Specific Directories
 The below configuration wll allow you to automatically apply changes on files under chezmoi source path.

--- a/lua/chezmoi/commands/__edit.lua
+++ b/lua/chezmoi/commands/__edit.lua
@@ -40,6 +40,13 @@ function M.watch(bufnr, force)
   force = force or config.edit.force
 
   local source_path = vim.api.nvim_buf_get_name(bufnr)
+  
+  -- Check if this file should be ignored
+  if util.should_ignore_file(source_path, config.edit.ignore_patterns) then
+    log.info("Skipping watch setup for ignored file: " .. vim.fn.fnamemodify(source_path, ":t"))
+    return
+  end
+
   local status_err = nil
   status.execute {
     args = {

--- a/lua/chezmoi/init.lua
+++ b/lua/chezmoi/init.lua
@@ -5,6 +5,15 @@ local default_config = {
   edit = {
     watch = false,
     force = false,
+    ignore_patterns = {
+      "run_onchange_.*",
+      "run_once_.*", 
+      "%.chezmoiignore",
+      "%.chezmoitemplate",
+      "%.chezmoiexternal.*",
+      "%.chezmoiroot",
+      "%.chezmoiversion",
+    },
   },
   events = {
     on_open = {

--- a/lua/chezmoi/util.lua
+++ b/lua/chezmoi/util.lua
@@ -83,4 +83,24 @@ function M.__arr_contains_one_of(tbl, values)
   return false
 end
 
+--- Check if a filename matches any of the ignore patterns
+---@param filename string
+---@param patterns string[]
+---@return boolean
+function M.should_ignore_file(filename, patterns)
+  if not patterns or vim.tbl_isempty(patterns) then
+    return false
+  end
+
+  local basename = vim.fn.fnamemodify(filename, ":t")
+  
+  for _, pattern in ipairs(patterns) do
+    if string.match(basename, pattern) then
+      return true
+    end
+  end
+  
+  return false
+end
+
 return M

--- a/tests/commands/__edit_spec.lua
+++ b/tests/commands/__edit_spec.lua
@@ -1,4 +1,5 @@
 local edit_cmd = require("chezmoi.commands.__edit")
+local util = require("chezmoi.util")
 
 describe("Test __edit.__parse_custom_opts", function()
   local test_results = {}
@@ -34,4 +35,28 @@ describe("Test __edit.__parse_custom_opts", function()
   for _, v in pairs(test_results) do
     assert(v.expected == v.actual)
   end
+end)
+
+-- Add test cases for the ignore patterns functionality
+
+describe("edit command ignore patterns", function()
+  local util = require("chezmoi.util")
+  
+  it("should ignore run_onchange files", function()
+    local filename = "/path/to/run_onchange_install_packages.sh"
+    local patterns = {"run_onchange_.*"}
+    assert.is_true(util.should_ignore_file(filename, patterns))
+  end)
+  
+  it("should ignore .chezmoiignore files", function()
+    local filename = "/path/to/.chezmoiignore"
+    local patterns = {"%.chezmoiignore"}
+    assert.is_true(util.should_ignore_file(filename, patterns))
+  end)
+  
+  it("should not ignore regular files", function()
+    local filename = "/path/to/dot_vimrc"
+    local patterns = {"run_onchange_.*", "%.chezmoiignore"}
+    assert.is_false(util.should_ignore_file(filename, patterns))
+  end)
 end)


### PR DESCRIPTION
- Add `ignore_patterns` configuration option under edit settings
- Add `should_ignore_file() utility function for pattern matching
- Modify `watch()` function to check ignore patterns before auto_apply
- Include sensible defaults fro common chezmoi meta-files
- Add comprehensive tests for ignore patters functionality

Fixes #40