### PR TITLE
fix: make fzf-lua's "pick" implementation use raw_cmd and pass opts through

### DIFF
--- a/lua/chezmoi/pick.lua
+++ b/lua/chezmoi/pick.lua
@@ -98,8 +98,8 @@ M.fzf = function(targets, args)
 
   local fzf_lua = require "fzf-lua"
   local actions = {
-    ["enter"] = function(selected)
-      fzf_lua.actions.vimcmd_entry("ChezmoiEdit", selected, { cwd = vim.env.HOME })
+    ["enter"] = function(selected, opts)
+      fzf_lua.actions.vimcmd_entry("ChezmoiEdit", selected, opts)
     end,
   }
   local makestr = function(obj)
@@ -115,10 +115,9 @@ M.fzf = function(targets, args)
   targets = makestr(targets)
   local args_str = makestr(args)
   fzf_lua.files {
-    cmd = "chezmoi managed" .. args_str .. targets,
+    raw_cmd = "chezmoi managed" .. args_str .. targets,
     actions = actions,
     cwd = vim.env.HOME,
-    hidden = false,
   }
 end
 


### PR DESCRIPTION
`raw_cmd` skips fzf-lua's handling of command editing for things like toggling hidden files, following symlinks, ignoring files, etc, which are only applicable to "find-like" utilities with associated command line parameters for those features. We want to pass the chezmoi command unchanged all the way through the fzf-lua layers, which is what `raw_cmd` is for.

Additionally, we need to pass through the second argument passed to action callbacks (`opts`) to the `vimcmd_entry()` call so that entries can be properly denormalized to a full path based on the fzf-lua display options that might be set in user's configs.